### PR TITLE
Add ability to add case custom properties

### DIFF
--- a/src/controllers/eventsController.ts
+++ b/src/controllers/eventsController.ts
@@ -16,6 +16,8 @@ export const handleEvent = async (req: Request, res: Response) => {
     case 'realtime.session.triage-flow.grouped-flow-value-collector-blocks-updated':
         eventHandlers.handleGroupedFlowValueCollectorBlocksUpdated(data);
       break;
+    case 'realtime.session.case-id-changed':
+        eventHandlers.handleSessionCaseIDChanged(data);
     case 'realtime.session-opened':
     case 'realtime.session-closed':
     case 'app.logout':

--- a/src/controllers/sessionController.ts
+++ b/src/controllers/sessionController.ts
@@ -12,9 +12,12 @@ import {
   StartSessionResponse,
 } from "../types/apiResponses";
 
+interface OpenSessionParams {
+  externalId: string;
+}
+
 export const openSession = async (req: Request, res: Response) => {
-  let data = req.body;
-  const externalId = data.externalID.toString();
+  let {externalId} = req.body.data as OpenSessionParams;
 
   const { activeSessions } =
     ((await cortiCallMethod(

--- a/src/eventHandlers/handleSessionCaseIDChanged.ts
+++ b/src/eventHandlers/handleSessionCaseIDChanged.ts
@@ -1,0 +1,20 @@
+import { updateCaseCustomProperties } from "../services/cortiServices";
+import { Session } from "../types/events";
+
+interface SessionCaseIDChangedBody {
+    session: Session;
+}
+
+const handleSessionCaseIDChanged = async (data: SessionCaseIDChangedBody) => {
+  const { session } = data;
+  if (session.caseID) {
+    // fetch custom properties for the case, either from the CAD or in memory
+    const customProperties = {
+        "telephone": "1234567890",
+        "location": "34 Elm St, Springfield, IL"
+    }
+    await updateCaseCustomProperties(session.caseID, customProperties);
+  }
+};
+
+export default handleSessionCaseIDChanged;

--- a/src/eventHandlers/index.ts
+++ b/src/eventHandlers/index.ts
@@ -1,3 +1,4 @@
 export { default as handleCommentCreated } from './handleCommentCreated';
 export { default as handleActionBlockTriggered } from './handleActionBlockTriggered';
 export { default as handleGroupedFlowValueCollectorBlocksUpdated } from './handleGroupedFlowValueCollectorBlocksUpdated';
+export { default as handleSessionCaseIDChanged } from './handleSessionCaseIDChanged';

--- a/src/services/cortiServices.ts
+++ b/src/services/cortiServices.ts
@@ -11,6 +11,9 @@ interface IFactUpdate {
   value: string;
 }
 
+type CaseCustomProperties = Record<string, string>; // String values for all properties
+
+
 export const cortiCallMethod = async (method: string, params?: IParams) => {
     const body = JSON.stringify({ method, params });
   
@@ -50,6 +53,27 @@ export const updateFactValues = async (
         "x-api-key": apiKey,
       },
       body: JSON.stringify(factUpdateBody),
+    }
+  );
+};
+
+export const updateCaseCustomProperties = async (
+  caseId: string,
+  customPropertiesBody: CaseCustomProperties
+) => {
+  const apiHost = await getApiHost();
+  const apiKey = getApiKey(apiHost);
+  if (!apiKey) return console.error(`No API key found for ${apiHost}`);
+
+  fetch(
+    `${apiHost}/public/api/v2.0/cases/${caseId}/custom-properties`,
+    {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": apiKey,
+      },
+      body: JSON.stringify(customPropertiesBody),
     }
   );
 };

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -67,7 +67,7 @@ interface CustomProperty {
   value: string;
 }
 
-interface Session {
+export interface Session {
   id: string;
   caseID?: string;
   externalID?: string;


### PR DESCRIPTION
Note, because the case ID is not always available at session creation, you need to wait for the case-id-changed event. This is because the case ID is generated by the server, and therefore not always available (e.g. in offline mode).