### PR TITLE
Fix openSession build error and surface FVC custom properties

### DIFF
--- a/src/controllers/sessionController.ts
+++ b/src/controllers/sessionController.ts
@@ -9,14 +9,20 @@ import {
   ActiveSessionsResponse,
   CurrentUserResponse,
   DBSession,
+  IFactUpdate,
   StartSessionResponse,
 } from "../types/apiResponses";
 
 interface OpenSessionParams {
   externalId: string;
+  facts?: IFactUpdate;
 }
 
 export const openSession = async (req: Request, res: Response) => {
+  const data = req.body.data as OpenSessionParams;
+  if (!data || !data.externalId) {
+    return res.status(400).send({ message: "Missing externalId" });
+  }
   let {externalId} = req.body.data as OpenSessionParams;
 
   const { activeSessions } =

--- a/src/controllers/sessionController.ts
+++ b/src/controllers/sessionController.ts
@@ -23,7 +23,7 @@ export const openSession = async (req: Request, res: Response) => {
   if (!data || !data.externalId) {
     return res.status(400).send({ message: "Missing externalId" });
   }
-  let {externalId} = req.body.data as OpenSessionParams;
+  const { externalId } = data;
 
   const { activeSessions } =
     ((await cortiCallMethod(

--- a/src/eventHandlers/handleActionBlockTriggered.ts
+++ b/src/eventHandlers/handleActionBlockTriggered.ts
@@ -28,7 +28,6 @@ const handleActionBlockTriggered = async (data: ActionBlockTriggered) => {
   // TODO: Set typecode and subtypecode in CAD
   factUpdateBody.forEach((fact) => {
     if(fact.value){
-      console.log(session.id)
       console.log(`New Typecode: ${fact.id} - ${fact.value} (External Session ID: ${session.externalID})`);
     }
   });

--- a/src/eventHandlers/handleActionBlockTriggered.ts
+++ b/src/eventHandlers/handleActionBlockTriggered.ts
@@ -29,7 +29,7 @@ const handleActionBlockTriggered = async (data: ActionBlockTriggered) => {
   factUpdateBody.forEach((fact) => {
     if(fact.value){
       console.log(session.id)
-      console.log(`New Typecode: ${fact.id} - ${fact.value} (Session ID: ${session.externalID})`);
+      console.log(`New Typecode: ${fact.id} - ${fact.value} (External Session ID: ${session.externalID})`);
     }
   });
   

--- a/src/eventHandlers/handleCommentCreated.ts
+++ b/src/eventHandlers/handleCommentCreated.ts
@@ -4,7 +4,7 @@ const handleCommentCreated = async (data: CommentCreated) => {
   const { comment, session } = data;
   // TODO: update your application with the comment
   console.log(
-    `New Comment: ${comment.text} (Session ID: ${session.externalID})`
+    `New Comment: ${comment.text} (External Session ID: ${session.externalID})`
   );
 };
 

--- a/src/eventHandlers/handleGroupedFlowValueCollectorBlocksUpdated.ts
+++ b/src/eventHandlers/handleGroupedFlowValueCollectorBlocksUpdated.ts
@@ -1,16 +1,55 @@
-import { GroupedFlowValueCollectorBlocksUpdated } from "../types/events";
+import { GroupedFlowValueCollectorBlocksUpdated, CustomProperty } from "../types/events";
+
+interface ISelectUpdates {
+  blockPrototypeId?: string;
+  value?: string;
+  text: string;
+  customProperties?: CustomProperty[];
+}
 
 const handleGroupedFlowValueCollectorBlocksUpdated = async (
   data: GroupedFlowValueCollectorBlocksUpdated
 ) => {
   const { group, session } = data;
+
+  const selectUpdates: ISelectUpdates[] = []
+
   group.forEach((block) => {
     if (block.displayValues.length === 0) return;
     const textString = block.displayValues.map((obj) => obj.text).join(" | ");
 
-    // TODOL update your application with the concatenated string value for each collector
+    const { values, blockPrototypes } = block.collectedBlockValues;
+    
+    values.forEach((collectedBlockValue) => {
+
+      const blockPrototype = blockPrototypes.find(
+          (bp) => bp.id === collectedBlockValue.blockPrototypeID
+        )
+
+      const newCollectedBlock: ISelectUpdates = {
+        blockPrototypeId: blockPrototype?.id,
+        customProperties: blockPrototype?.customProperties || [],
+        ...collectedBlockValue
+      };
+
+      selectUpdates.push(newCollectedBlock)
+    })
+    // TODO: update your application with the concatenated string value for each collector
     console.log(
-      `New Collector: ${block.blockPrototype.name} - ${textString} (Session ID: ${session.externalID})`
+      `New Collector: ${block.blockPrototype.name} - ${textString} (External Session ID: ${session.externalID})`
+    );
+  });
+
+  // make selectUpdates unique by blockPrototype.id
+  const uniqueSelectUpdates = Array.from(
+    new Map(selectUpdates.map((item) => [item.blockPrototypeId, item])).values()
+  ).filter((item => item.customProperties && item.customProperties.length > 0));
+
+  // TODO: update your application with the collected custom properties per block
+  uniqueSelectUpdates.forEach((update) => {
+    console.log(
+      `Collector custom properties: ${update.text} (External Session ID: ${session.externalID})`,
+      update.customProperties
     );
   });
 };

--- a/src/eventHandlers/handleGroupedFlowValueCollectorBlocksUpdated.ts
+++ b/src/eventHandlers/handleGroupedFlowValueCollectorBlocksUpdated.ts
@@ -1,10 +1,10 @@
 import { GroupedFlowValueCollectorBlocksUpdated, CustomProperty } from "../types/events";
 
 interface ISelectUpdates {
-  blockPrototypeId?: string;
+  blockPrototypeId: string;
   value?: string;
   text: string;
-  customProperties?: CustomProperty[];
+  customProperties: CustomProperty[];
 }
 
 const handleGroupedFlowValueCollectorBlocksUpdated = async (
@@ -21,18 +21,19 @@ const handleGroupedFlowValueCollectorBlocksUpdated = async (
     const { values, blockPrototypes } = block.collectedBlockValues;
     
     values.forEach((collectedBlockValue) => {
-
       const blockPrototype = blockPrototypes.find(
-          (bp) => bp.id === collectedBlockValue.blockPrototypeID
-        )
+        (bp) => bp.id === collectedBlockValue.blockPrototypeID
+      );
+      // Skip values we can't tie back to a prototype, otherwise they would
+      // collapse under a single `undefined` key during dedupe below.
+      if (!blockPrototype) return;
 
-      const newCollectedBlock: ISelectUpdates = {
-        blockPrototypeId: blockPrototype?.id,
-        customProperties: blockPrototype?.customProperties || [],
-        ...collectedBlockValue
-      };
-
-      selectUpdates.push(newCollectedBlock)
+      // Spread first so the prototype-level fields below always win.
+      selectUpdates.push({
+        ...collectedBlockValue,
+        blockPrototypeId: blockPrototype.id,
+        customProperties: blockPrototype.customProperties || [],
+      });
     })
     // TODO: update your application with the concatenated string value for each collector
     console.log(

--- a/src/services/cortiServices.ts
+++ b/src/services/cortiServices.ts
@@ -1,6 +1,6 @@
 import { Call, CallsResponse, DBSession, DBSessionsResponse } from "../types/apiResponses";
 import { getApiHost, getApiKey } from "../utils/utils";
-const clientHost = process.env.clientHost;
+const clientHost = process.env.CLIENTHOST;
 
 interface IParams {
   [key: string]: any;

--- a/src/services/cortiServices.ts
+++ b/src/services/cortiServices.ts
@@ -1,6 +1,6 @@
 import { Call, CallsResponse, DBSession, DBSessionsResponse } from "../types/apiResponses";
 import { getApiHost, getApiKey } from "../utils/utils";
-const clientHost = process.env.CLIENTHOST;
+const clientHost = process.env.CLIENTHOST || "http://localhost:45001";
 
 interface IParams {
   [key: string]: any;

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -62,7 +62,7 @@ interface FlowValueCollectorPayload {
   };
 }
 
-interface CustomProperty {
+export interface CustomProperty {
   key: string;
   value: string;
 }


### PR DESCRIPTION
## Summary

Curates the meaningful uncommitted work that had accumulated on `master` into a clean change set. Three substantive fixes plus minor log-wording consistency. Debug logging, an accidental `import e,` typo, switch-case re-indentation, duplicate test scripts, and unrelated readme/package.json edits were intentionally excluded.

## Changes

- **Build fix (`sessionController.ts`)** — `master` did not compile (`TS2304: Cannot find name 'data'` in `openSession`). Declares `const data = req.body.data`, types `facts?` on `OpenSessionParams`, and adds a 400 guard for a missing `externalId`.
- **Feature (`handleGroupedFlowValueCollectorBlocksUpdated.ts`)** — collects each block's `customProperties`, dedupes by `blockPrototypeId`, and exposes them to the integration.
- **Type (`events.ts`)** — exports `CustomProperty` so the handler can import it.
- **Env-var fix (`cortiServices.ts`)** — reads `process.env.CLIENTHOST` (the documented var) instead of the never-set `process.env.clientHost`, which was always `undefined`.
- **Cosmetic** — log wording "Session ID" → "External Session ID" for consistency.

## Verification

`npx tsc --noEmit` exits 0 (previously failed on `master`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
